### PR TITLE
Rename object to avoid naming conflicts

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,10 @@ videojs("example_video_1").ready(function () {
     this.disableProgress();
 
     if(enabled){
-       this.disableProgress.enable();
+       this.controlProgress.enable();
     }
     else{
-        this.disableProgress.disable();
+        this.controlProgress.disable();
     }
 });
 ```
@@ -42,10 +42,10 @@ videojs("example_video_1").ready(function () {
   player.disableProgress();
 
   //something changes where you need to disable:
-  player.disableProgress.disable();
+  player.controlProgress.disable();
 
   //some awesome event happens when you need to enable:
-  player.disableProgress.enable()
+  player.controlProgress.enable()
 });
 ```
 

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "videojs-disable-progress",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "homepage": "https://github.com/rsadwick/videojs-disable-progress",
   "authors": [
     "Ryan Sadwick <rsadwick@gmail.com>"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "videojs-disableUi",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "author": {
     "name": "Ryan Sadwick",
     "email": "rsadwick@gmail.com"

--- a/src/videojs.disableProgress.js
+++ b/src/videojs.disableProgress.js
@@ -41,7 +41,7 @@
         settings = extend({}, defaults, options || {});
 
       // disable / enable methods
-      player.disableProgress = {
+      player.controlProgress = {
         disable: function() {
             state = true;
             player.controlBar.progressControl.seekBar.off("mousedown");
@@ -61,7 +61,7 @@
 
       if(settings.autoDisable)
       {
-        player.disableProgress.disable();
+        player.controlProgress.disable();
       }
     };
 

--- a/test/disableProgress.test.js
+++ b/test/disableProgress.test.js
@@ -59,8 +59,8 @@
     test('plugin api methods exist', function() {
         expect(2);
         this.player.disableProgress();
-        ok(this.player.disableProgress.disable, 'disable exists');
-        ok(this.player.disableProgress.enable, 'enable exists');
+        ok(this.player.controlProgress.disable, 'disable exists');
+        ok(this.player.controlProgress.enable, 'enable exists');
     });
 
     test('autoDisable option can be overridden to true', function() {
@@ -69,7 +69,7 @@
           autoDisable: true
         });
 
-        strictEqual(this.player.disableProgress.getState(), true, 'returns true');
+        strictEqual(this.player.controlProgress.getState(), true, 'returns true');
     });
 
     test('autoDisable option can be overridden to false', function() {
@@ -78,7 +78,7 @@
           autoDisable: false
         });
 
-        strictEqual(this.player.disableProgress.getState(), false, 'returns false');
+        strictEqual(this.player.controlProgress.getState(), false, 'returns false');
     });
 
 }(window.videojs));


### PR DESCRIPTION
Rename object to avoid naming conflicts with `disableProgress` function.